### PR TITLE
Fixing the position of the modal close button

### DIFF
--- a/src/components/modal.js
+++ b/src/components/modal.js
@@ -51,12 +51,14 @@ const Wrapper = styled.div`
 
 const CloseButton = styled.button`
   position: absolute;
+  z-index: 9090;
   right: 50px;
   top: 50px;
   width: 80px;
   height: 80px;
   border-radius: 100%;
   background: var(--white);
+  box-shadow: var(--shadow);
 
   :hover,
   :focus,

--- a/src/scaffold.scss
+++ b/src/scaffold.scss
@@ -9,6 +9,7 @@
   --radius: 100px;
   --container: 1366px;
   --highlight-circle: 0 0 0 2px var(--white), 0 0 0px 4px var(--blue);
+  --shadow: 0 2px 18px 0 rgba(0, 0, 0, .1);
 
   --f-big: 32px;
   --f-regular: 14px;


### PR DESCRIPTION
This Pull Request fixes the position of the modal close button and adds a shadow box that highlights the button.
Now, it's possible to click at the close button.

**Before:**
![fbr-before](https://user-images.githubusercontent.com/3259312/47366437-ac1af680-d6ab-11e8-8c2f-16ec3f041cb3.png)

**After:**
![fbr-after](https://user-images.githubusercontent.com/3259312/47366465-bc32d600-d6ab-11e8-8e25-9569e341666d.png)
